### PR TITLE
chore: add *.so and *.pyd to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Python
 __pycache__/
 *.py[oc]
+*.so
+*.pyd
 build/
 dist/
 wheels/


### PR DESCRIPTION
## Summary
- Exclude compiled native extension artifacts from version control

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>