### PR TITLE
fix: CI wheel builds and docs sidebar

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           # macOS
           - os: macos-14
             target: aarch64-apple-darwin
-          - os: macos-13
+          - os: macos-14
             target: x86_64-apple-darwin
           # Linux
           - os: ubuntu-latest
@@ -60,6 +60,8 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
     runs-on: ${{ matrix.os }}
+    env:
+      RUST_FONTCONFIG_DLOPEN: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,10 +29,8 @@ theme:
   features:
     - navigation.instant
     - navigation.tracking
-    - navigation.tabs
-    - navigation.sections
-    - navigation.expand
     - navigation.top
+    - toc.integrate
     - search.suggest
     - search.highlight
     - content.code.copy


### PR DESCRIPTION
## Summary
- Replace deprecated `macos-13` runner with `macos-14` for x86_64 cross-compilation
- Set `RUST_FONTCONFIG_DLOPEN=1` to fix Linux aarch64 cross-build (`fontconfig-sys` link failure)
- Remove `navigation.tabs`/`sections`/`expand` from mkdocs — redundant with only 4 pages
- Add `toc.integrate` so sidebar shows page headings instead of duplicating top nav

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>