### PR TITLE
Restore ABOUTME header in extra.css

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,5 +1,5 @@
-/* All Tuner Labs brand colors and MkDocs Material theme overrides. */
-/* Provides wine/burgundy color scheme with light/dark mode support. */
+/* ABOUTME: All Tuner Labs brand colors and MkDocs Material theme overrides. */
+/* ABOUTME: Provides wine/burgundy color scheme with light/dark mode support. */
 
 /* All Tuner Labs Brand Colors */
 :root {


### PR DESCRIPTION
## Summary
- Restores the two-line `ABOUTME:` comment header that had drifted out of `docs/stylesheets/extra.css`.
- After this change the file matches the canonical brand mkdocs theme byte-for-byte (now hosted at [`alltuner/brand:mkdocs-theme/stylesheets/extra.css`](https://github.com/alltuner/brand/blob/main/mkdocs-theme/stylesheets/extra.css), replacing the now-archived `alltuner/mkdocs-theme`).
- Also re-aligns with the project convention that every file starts with two `ABOUTME:` lines.

## Test plan
- [ ] `mkdocs serve` still renders correctly (header comment only — no functional CSS change).