### PR TITLE
docs: standardize README to alltuner brand structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-<h1 align="center">Silicate</h1>
+<p align="center">
+  <img src="https://brand.alltuner.com/logos/silicate/horizontal.png" alt="Silicate" width="500">
+</p>
 
 <p align="center">
   <strong>Python bindings for <a href="https://github.com/Aloxaf/silicon">Silicon</a>'s renderer.</strong><br>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/sponsors/alltuner">Sponsor</a>
+  <a href="https://alltuner.com/sponsor">Sponsor</a>
 </p>
 
 <p align="center">
@@ -138,15 +138,7 @@ uv run python -c "import silicate; print(silicate.list_themes())"
 
 Silicate is an open source project built by [David Poblador i Garcia](https://davidpoblador.com/) through [All Tuner Labs](https://www.alltuner.com/).
 
-If this project saved you a screenshot session, consider supporting its development.
-
-❤️ **Sponsor development**
-https://github.com/sponsors/alltuner
-
-☕ **One-time support**
-https://buymeacoffee.com/alltuner
-
-Your support helps fund the continued development of Silicate and other open source developer tools such as [Factory Floor](https://github.com/alltuner/factoryfloor).
+If this project was useful to you, [consider supporting its development](https://alltuner.com/sponsor).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -134,15 +134,15 @@ VIRTUAL_ENV=.venv uvx maturin develop
 uv run python -c "import silicate; print(silicate.list_themes())"
 ```
 
+## License
+
+[MIT](LICENSE)
+
 ## Support the project
 
 Silicate is an open source project built by [David Poblador i Garcia](https://davidpoblador.com/) through [All Tuner Labs](https://www.alltuner.com/).
 
 If this project was useful to you, [consider supporting its development](https://alltuner.com/sponsor).
-
-## License
-
-[MIT](LICENSE)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,61 @@
-# Silicate
-
-**Python bindings for [Silicon](https://github.com/Aloxaf/silicon)'s renderer — create beautiful images of your source code, powered by Rust.**
+<h1 align="center">Silicate</h1>
 
 <p align="center">
-  <img src="docs/assets/hero-example.png" alt="Silicate example - Python code rendered with Dracula theme" width="700">
+  <strong>Python bindings for <a href="https://github.com/Aloxaf/silicon">Silicon</a>'s renderer.</strong><br>
+  Create beautiful images of your source code, powered by Rust.
 </p>
 
-Unlike wrapper approaches that shell out to a CLI, Silicate uses [PyO3](https://pyo3.rs) to call Silicon's Rust library directly, giving you native performance with a clean Python API.
+<p align="center">
+  <a href="https://github.com/sponsors/alltuner">Sponsor</a>
+</p>
 
-## Installation
+<p align="center">
+  <img src="https://img.shields.io/pypi/v/silicate?color=5B2333" alt="PyPI">
+  <img src="https://img.shields.io/github/license/alltuner/silicate?color=5B2333" alt="License">
+  <img src="https://img.shields.io/github/stars/alltuner/silicate?color=5B2333" alt="Stars">
+</p>
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/alltuner/silicate/main/docs/assets/hero-example.png" alt="Silicate example: Python code rendered with the Dracula theme" width="700">
+</p>
+
+---
+
+## Get Started
 
 ```bash
 uv add silicate
 ```
 
-**Build from source** (requires Rust toolchain):
+```python
+import silicate
 
-```bash
-git clone --recurse-submodules https://github.com/alltuner/silicate.git
-cd silicate
-uv sync
+png_bytes = silicate.generate(
+    "print('Hello, World!')",
+    language="python",
+    theme="Dracula",
+)
 ```
+
+---
+
+## What is Silicate?
+
+Silicate is a Python binding for [Silicon](https://github.com/Aloxaf/silicon), the Rust tool that turns source code into beautifully rendered PNGs. Unlike wrapper approaches that shell out to a CLI, Silicate uses [PyO3](https://pyo3.rs) to call Silicon's Rust library directly, giving you native performance with a clean Python API.
+
+### Features
+
+- **Native performance** — no subprocess, no temp files; the renderer runs in-process via PyO3.
+- **24+ built-in themes** — Dracula, Nord, Monokai, GitHub, Solarized, and more.
+- **Full Silicon control** — every renderer option exposed as a keyword argument.
+- **PNG bytes or file** — `generate()` returns bytes, `to_file()` writes directly.
 
 ## Usage
 
 ```python
 import silicate
 
-# Generate PNG bytes
+# PNG bytes
 png_bytes = silicate.generate(
     "print('Hello, World!')",
     language="python",
@@ -48,22 +76,20 @@ print(silicate.list_themes())
 print(silicate.list_languages())
 ```
 
-## Theme gallery
-
-Silicate ships with 24+ built-in themes. Here are a few:
+### Theme gallery
 
 <table>
   <tr>
-    <td align="center"><strong>Dracula</strong><br><img src="docs/assets/hero-example.png" width="400"></td>
-    <td align="center"><strong>Nord</strong><br><img src="docs/assets/example-nord.png" width="400"></td>
+    <td align="center"><strong>Dracula</strong><br><img src="https://raw.githubusercontent.com/alltuner/silicate/main/docs/assets/hero-example.png" width="400"></td>
+    <td align="center"><strong>Nord</strong><br><img src="https://raw.githubusercontent.com/alltuner/silicate/main/docs/assets/example-nord.png" width="400"></td>
   </tr>
   <tr>
-    <td align="center"><strong>Monokai Extended</strong><br><img src="docs/assets/example-monokai.png" width="400"></td>
-    <td align="center"><strong>GitHub</strong><br><img src="docs/assets/example-github.png" width="400"></td>
+    <td align="center"><strong>Monokai Extended</strong><br><img src="https://raw.githubusercontent.com/alltuner/silicate/main/docs/assets/example-monokai.png" width="400"></td>
+    <td align="center"><strong>GitHub</strong><br><img src="https://raw.githubusercontent.com/alltuner/silicate/main/docs/assets/example-github.png" width="400"></td>
   </tr>
   <tr>
-    <td align="center"><strong>Solarized Dark</strong><br><img src="docs/assets/example-solarized.png" width="400"></td>
-    <td align="center"><strong>Your code here</strong><br><img src="docs/assets/example-usage.png" width="400"></td>
+    <td align="center"><strong>Solarized Dark</strong><br><img src="https://raw.githubusercontent.com/alltuner/silicate/main/docs/assets/example-solarized.png" width="400"></td>
+    <td align="center"><strong>Your code here</strong><br><img src="https://raw.githubusercontent.com/alltuner/silicate/main/docs/assets/example-usage.png" width="400"></td>
   </tr>
 </table>
 
@@ -108,10 +134,27 @@ VIRTUAL_ENV=.venv uvx maturin develop
 uv run python -c "import silicate; print(silicate.list_themes())"
 ```
 
+## Support the project
+
+Silicate is an open source project built by [David Poblador i Garcia](https://davidpoblador.com/) through [All Tuner Labs](https://www.alltuner.com/).
+
+If this project saved you a screenshot session, consider supporting its development.
+
+❤️ **Sponsor development**
+https://github.com/sponsors/alltuner
+
+☕ **One-time support**
+https://buymeacoffee.com/alltuner
+
+Your support helps fund the continued development of Silicate and other open source developer tools such as [Factory Floor](https://github.com/alltuner/factoryfloor).
+
 ## License
 
-MIT
+[MIT](LICENSE)
 
 ---
 
-Built by [All Tuner Labs](https://alltuner.com)
+<p align="center">
+  Built by <a href="https://davidpoblador.com">David Poblador i Garcia</a> with the support of <a href="https://alltuner.com">All Tuner Labs</a>.<br>
+  Made with ❤️ in Poblenou, Barcelona.
+</p>


### PR DESCRIPTION
## Summary

- Adds the centered hero (title, tagline, link row, Wine-coloured shields, hero image).
- Switches all image references from relative paths (`docs/assets/…`) to absolute `raw.githubusercontent.com` URLs so the README renders on PyPI.
- Adds a Features list under "What is Silicate?".
- Adds the canonical sponsor block.
- Replaces the single-line footer with the canonical centered Poblenou signature.

Follows the canonical README template at `alltuner/brand:readme-template`.

## Test plan

- [ ] Render on github.com and verify the centered hero, shields, and theme gallery still align.
- [ ] Render on PyPI on next release and confirm the hero image and theme gallery now resolve (they currently 404 there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)